### PR TITLE
Corrects default cron schedule, to run *every* month

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ COPY --from=builder /app /app
 # Set working directory
 WORKDIR /app
 
-# Set default cron schedule (30 days)
-ENV CRON_SCHEDULE="0 0 0 */30 * *"
+# Set default cron schedule (the 15th of each month)
+ENV CRON_SCHEDULE="0 0 0 15 * *"
 # Environment variable to control immediate execution
 ENV RUN_ON_STARTUP="false"
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This Docker image is designed to automatically restart specified Docker containe
 
 ## Features
 - Automated Container Restart: Restart specified Docker containers.
-- (optional)Discord Notifications: Sends a message to a Discord channel after each container restart.
-- (optional)Slack Notifications: Sends a message to a Slack channel after each container restart.
+- (optional) Discord Notifications: Sends a message to a Discord channel after each container restart.
+- (optional) Slack Notifications: Sends a message to a Slack channel after each container restart.
 
 ## Running the Container
 Run the container with the following command:
@@ -22,7 +22,7 @@ docker run -d \
 ```
 
 ## Environment Variables
-- CRON_SCHEDULE: every 30 days by default
+- CRON_SCHEDULE: the 15th of every month, by default
 - RESTART_CONTAINERS: A comma-separated list of container names to be restarted.
 - CYCLE_PERIOD: delay between container restarts, 10000ms (10 sec) by default
 - RUN_ON_STARTUP: control immediate execution, false by default

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,5 +46,5 @@ fi
 #        -d N    Set log level, log to stderr
 #        -L FILE Log to FILE
 #        -c DIR  Cron dir. Default:/var/spool/cron/crontabs
-echo "Starting cron daemon in the foreground - $CRON_SCHEDULE"
+echo "Starting cron daemon in the foreground: $CRON_SCHEDULE"
 exec crond -f -d 8


### PR DESCRIPTION
A cron value of "0 0 0 */30 * *" runs on the 30th of every month except February.  This changes the default to "0 0 0 15 * *", the 15th of every month.  I chose the 15th to avoid the rush of cron jobs running the first day of every month.

There's also a couple trivial output message changes, to help readability.

Fixes Issue #54 